### PR TITLE
[TASK] corrected spelling from wallio to wallsio

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@
 
 $EM_CONF[$_EXTKEY] = [
     'title' => 'chr_wallsio',
-    'description' => 'integrates wall.io',
+    'description' => 'Integrates walls.io',
     'category' => 'plugin',
     'author' => 'Christian Rath',
     'author_email' => 'christian.rath@publicispixelpark.de',


### PR DESCRIPTION
Change extension manager description lines, which are also used in public TYPO3 Extension Repository website, to describe extension.